### PR TITLE
Fixes linker error "ld: framework not found ./MobileDevice" caused by clang upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	cp -a /System/Library/PrivateFrameworks/MobileDevice.framework ./MobileDevice.framework
+	rsync -r /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework "./" --exclude=XPCServices --links
 	gcc -o udidetect -framework CoreFoundation -framework MobileDevice -F/`pwd` udidetect.c
 install:
 	cp udidetect /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all:
+	cp -a /System/Library/PrivateFrameworks/MobileDevice.framework ./MobileDevice.framework
 	gcc -o udidetect -framework CoreFoundation -framework MobileDevice -F/System/Library/PrivateFrameworks udidetect.c
 install:
 	cp udidetect /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	cp -a /System/Library/PrivateFrameworks/MobileDevice.framework ./MobileDevice.framework
-	gcc -o udidetect -framework CoreFoundation -framework ./MobileDevice.framework -F/System/Library/PrivateFrameworks udidetect.c
+	gcc -o udidetect -framework CoreFoundation -framework MobileDevice -F/`pwd` udidetect.c
 install:
 	cp udidetect /usr/local/bin/
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	cp -a /System/Library/PrivateFrameworks/MobileDevice.framework ./MobileDevice.framework
-	gcc -o udidetect -framework CoreFoundation -framework MobileDevice -F/System/Library/PrivateFrameworks udidetect.c
+	gcc -o udidetect -framework CoreFoundation -framework ./MobileDevice.framework -F/System/Library/PrivateFrameworks udidetect.c
 install:
 	cp udidetect /usr/local/bin/
 uninstall:


### PR DESCRIPTION
I think the latest clang upgrade now filters out frameworks in the `/System/Library/PrivateFrameworks` directory, because this repo's `Makefile` suddenly started giving us errors on our CI system, when installing the npm package (which issues a `make` command):
```
warning Error running install script for optional dependency: "[FILTERED]/node_modules/udidetect: Command failed.
Exit code: 2
Command: make
Arguments: 
Directory: /[FILTERED]/node_modules/udidetect
Output:
gcc -o udidetect -framework CoreFoundation -framework MobileDevice -F/System/Library/PrivateFrameworks udidetect.c
ld: framework not found MobileDevice
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [all] Error 1"
```

Another package, `ios-deploy` was giving the same error; [they fixed it](https://github.com/ios-control/ios-deploy/issues/387#issuecomment-506870488) by `rsyncing` the `MobileDevice.framework` out of the `System` directory and into the local directory.

So, that's what I did here. 

On OSX Catalina (10.15.7) / Apple clang version 12.0.0 (clang-1200.0.32.2), I can now run `make` and not hit the error.